### PR TITLE
Redis and custom counter support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,27 @@
 PATH
   remote: .
   specs:
-    rack-ratelimit (1.0.1)
-      dalli
+    rack-ratelimit (1.1.0)
       rack
 
 GEM
   remote: https://rubygems.org/
   specs:
-    dalli (2.7.0)
-    minitest (5.3.1)
-    rack (1.5.2)
-    rake (10.1.1)
+    dalli (2.7.6)
+    minitest (5.3.5)
+    rack (1.6.4)
+    rake (11.1.2)
+    redis (3.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  dalli
   minitest (~> 5.3.0)
   rack-ratelimit!
   rake
+  redis
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ Rack env, return a string such as IP address, API token, etc. If the
 block returns nil, the request won't be rate-limited. If a block is
 not given, all requests get the same limits.
 
-Options:
+Required configuration:
 * rate: an array of [max requests, period in seconds]: [500, 5.minutes]
-* cache: a Dalli::Client instance, or an object that quacks like it.
+
+and one of
+* cache: a Dalli::Client instance
+* redis: a Redis instance
+* counter: Your own custom counter. Must respond to `#increment(classification_string, end_of_time_window_timestamp)` and return the counter value after increment.
+
+Optional configuration:
 * name: name of the rate limiter. Defaults to 'HTTP'. Used in messages.
 * conditions: array of procs that take a rack env, all of which must
     return true to rate-limit the request.
@@ -51,5 +57,5 @@ Rate-limit API traffic by user (set by Rack::Auth::Basic)
     use(Rack::Ratelimit, name: 'API',
       conditions: ->(env) { env['REMOTE_USER'] },
       rate:   [1000, 1.hour],
-      cache:  Dalli::Client.new,
+      redis:  Redis.new(ratelimit_redis_config),
       logger: Rails.logger) { |env| env['REMOTE_USER'] }

--- a/rack-ratelimit.gemspec
+++ b/rack-ratelimit.gemspec
@@ -1,16 +1,20 @@
 Gem::Specification.new do |s|
   s.name    = 'rack-ratelimit'
-  s.version = '1.0.1'
-  s.author  = 'Jeremy Kemper'
-  s.email   = 'jeremy@bitsweat.net'
+  s.version = '1.1.0'
+  s.author  = 'Jeremy Daer'
+  s.email   = 'jeremydaer@gmail.com'
   s.summary = 'Flexible rate limits for your Rack apps'
   s.license = 'MIT'
 
   s.required_ruby_version = '>= 1.8'
 
   s.add_dependency 'rack'
-  s.add_dependency 'dalli'
 
+  # Optional dependencies. Use Memcached or Redis.
+  s.add_development_dependency 'dalli'
+  s.add_development_dependency 'redis'
+
+  # Actual dev-only deps.
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest', '~> 5.3.0'
 

--- a/test/ratelimit_test.rb
+++ b/test/ratelimit_test.rb
@@ -5,33 +5,28 @@ require 'minitest/autorun'
 require 'rack/ratelimit'
 require 'stringio'
 
-class RatelimitTest < Minitest::Test
+require 'dalli'
+require 'redis'
+
+module RatelimitTests
   def setup
-    @cache = Dalli::Client.new('localhost:11211').tap(&:flush)
+    @app = ->(env) { [200, {}, []] }
     @logger = Logger.new(@out = StringIO.new)
 
-    @app = ->(env) { [200, {}, []] }
-
-    @limited = Rack::Ratelimit.new(@app,
-      name: :one, rate: [1, 10],
-      cache: @cache, logger: @logger) { |env| 'classification' }
-
-    @two_limits = Rack::Ratelimit.new(@limited,
-      name: :two, rate: [1, 10],
-      cache: @cache, logger: @logger) { |env| 'classification' }
+    @limited = build_ratelimiter(@app, name: :one, rate: [1, 10])
+    @two_limits = build_ratelimiter(@limited, name: :two, rate: [1, 10])
   end
 
   def test_name_defaults_to_HTTP
-    app = Rack::Ratelimit.new(@app, rate: [1, 10], cache: @cache)
-    status, headers, body = app.call({})
-    assert_equal 200, status
-    assert_match '"name":"HTTP"', headers['X-Ratelimit']
+    app = build_ratelimiter(@app)
+    assert_match '"name":"HTTP"', app.call({})[1]['X-Ratelimit']
   end
 
   def test_sets_informative_header_when_rate_limit_isnt_exceeded
     status, headers, body = @limited.call({})
     assert_equal 200, status
     assert_match %r({"name":"one","period":10,"limit":1,"remaining":1,"until":".*"}), headers['X-Ratelimit']
+    assert_equal [], body
     assert_equal '', @out.string
   end
 
@@ -42,6 +37,7 @@ class RatelimitTest < Minitest::Test
     assert_equal 2, info.size
     assert_match %r({"name":"one","period":10,"limit":1,"remaining":1,"until":".*"}), info.first
     assert_match %r({"name":"two","period":10,"limit":1,"remaining":1,"until":".*"}), info.last
+    assert_equal [], body
     assert_equal '', @out.string
   end
 
@@ -53,11 +49,11 @@ class RatelimitTest < Minitest::Test
     assert_match '0', headers['X-Ratelimit']
     assert_match %r({"name":"one","period":10,"limit":1,"remaining":0,"until":".*"}), headers['X-Ratelimit']
     assert_equal 'one rate limit exceeded. Please wait 10 seconds then retry your request.', body.first
-    assert_match /one: classification exceeded 1 request limit for/, @out.string
+    assert_match %r{one: classification exceeded 1 request limit for}, @out.string
   end
 
   def test_optional_response_status
-    app = Rack::Ratelimit.new(@app, rate: [1, 10], status: 503, cache: @cache)
+    app = build_ratelimiter(@app, status: 503)
     assert_equal 200, app.call('limit-by' => 'key').first
     assert_equal 503, app.call('limit-by' => 'key').first
   end
@@ -71,12 +67,12 @@ class RatelimitTest < Minitest::Test
   end
 
   def test_classifier_is_optional
-    app = Rack::Ratelimit.new(@app, rate: [1, 10], cache: @cache)
+    app = build_ratelimiter(@app, no_classifier: true)
     assert_rate_limited app.call({})
   end
 
   def test_classify_may_be_overridden
-    app = Rack::Ratelimit.new(@app, rate: [1, 10], cache: @cache)
+    app = build_ratelimiter(@app, no_classifier: true)
     def app.classify(env) env['limit-by'] end
     assert_equal 200, app.call('limit-by' => 'a').first
     assert_equal 200, app.call('limit-by' => 'b').first
@@ -101,14 +97,13 @@ class RatelimitTest < Minitest::Test
   end
 
   def test_conditions_and_exceptions_as_config_options
-    app = Rack::Ratelimit.new(@app, rate: [1, 10], cache: @cache,
-      conditions: ->(env) { env['c1'] }) { |env| 'classification' }
+    app = build_ratelimiter(@app, conditions: ->(env) { env['c1'] })
     assert_rate_limited app.call('c1' => true)
     assert_not_rate_limited app.call('c1' => false)
   end
 
   def test_skip_rate_limiting_when_classifier_returns_nil
-    app = Rack::Ratelimit.new(@app, rate: [1, 10], cache: @cache) { |env| env['c'] }
+    app = build_ratelimiter(@app) { |env| env['c'] }
     assert_rate_limited app.call('c' => '1')
     assert_not_rate_limited app.call('c' => nil)
   end
@@ -121,4 +116,82 @@ class RatelimitTest < Minitest::Test
     def assert_rate_limited(response)
       assert !response[1]['X-Ratelimit'].nil?
     end
+
+    def build_ratelimiter(app, options = {}, &block)
+      block ||= -> env { 'classification' } unless options.delete(:no_classifier)
+      Rack::Ratelimit.new(app, ratelimit_options.merge(options), &block)
+    end
+
+    def ratelimit_options
+      { rate: [1,10], logger: @logger }
+    end
+end
+
+class RequiredBackendTest < Minitest::Test
+  def test_backend_is_required
+    assert_raises ArgumentError do
+      Rack::Ratelimit.new(nil, rate: [1,10])
+    end
+  end
+end
+
+class MemcachedRatelimitTest < Minitest::Test
+  include RatelimitTests
+
+  def setup
+    @cache = Dalli::Client.new('localhost:11211').tap(&:flush)
+    super
+  end
+
+  def teardown
+    super
+    @cache.close
+  end
+
+  private
+    def ratelimit_options
+      super.merge cache: @cache
+    end
+end
+
+class RedisRatelimitTest < Minitest::Test
+  include RatelimitTests
+
+  def setup
+    @redis = Redis.new(:host => 'localhost', :port => 6379, :db => 0).tap(&:flushdb)
+    super
+  end
+
+  def teardown
+    super
+    @redis.quit
+  end
+
+  private
+    def ratelimit_options
+      super.merge redis: @redis
+    end
+end
+
+class CustomCounterRatelimitTest < Minitest::Test
+  include RatelimitTests
+
+  private
+    def ratelimit_options
+      super.merge counter: Counter.new
+    end
+
+  class Counter
+    def initialize
+      @counters = Hash.new do |classifications, name|
+        classifications[name] = Hash.new do |timeslices, timestamp|
+          timeslices[timestamp] = 0
+        end
+      end
+    end
+
+    def increment(classification, timestamp)
+      @counters[classification][timestamp] += 1
+    end
+  end
 end


### PR DESCRIPTION
Built-in support for a Redis backend. Allow providing your own counter, such as an in-process expiring hash → hash → count.