### PR TITLE
Fix off by one remaining count

### DIFF
--- a/lib/rack/ratelimit.rb
+++ b/lib/rack/ratelimit.rb
@@ -128,14 +128,14 @@ module Rack
 
         # Increment the request counter.
         count = @counter.increment(classification, timestamp)
-        remaining = @max - count + 1
+        remaining = @max - count
 
-        json = %({"name":"#{@name}","period":#{@period},"limit":#{@max},"remaining":#{remaining},"until":"#{time}"})
+        json = %({"name":"#{@name}","period":#{@period},"limit":#{@max},"remaining":#{remaining < 0 ? 0 : remaining},"until":"#{time}"})
 
         # If exceeded, return a 429 Rate Limit Exceeded response.
-        if remaining <= 0
+        if remaining < 0
           # Only log the first hit that exceeds the limit.
-          if @logger && remaining == 0
+          if @logger && remaining == -1
             @logger.info '%s: %s exceeded %d request limit for %s' % [@name, classification, @max, time]
           end
 


### PR DESCRIPTION
* Fix that the `remaining` header value was one more than the actual limit
* Change `remaining` header value to always display `0` (instead of negative numbers) when rate limited

Failing tests before these changes:
```
  1) Failure:
CustomCounterRatelimitTest#test_decrements_rate_limit_header_remaining_count [test/ratelimit_test.rb:37]:
Expected: [2, 1, 0, 0, 0]
  Actual: [3, 2, 1, 0, -1]


  2) Failure:
MemcachedRatelimitTest#test_decrements_rate_limit_header_remaining_count [test/ratelimit_test.rb:37]:
Expected: [2, 1, 0, 0, 0]
  Actual: [3, 2, 1, 0, -1]


  3) Failure:
RedisRatelimitTest#test_decrements_rate_limit_header_remaining_count [test/ratelimit_test.rb:37]:
Expected: [2, 1, 0, 0, 0]
  Actual: [3, 2, 1, 0, -1]
```