### PR TITLE
Enable rate values to be set via proc

### DIFF
--- a/rack-ratelimit.gemspec
+++ b/rack-ratelimit.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name      = 'rack-ratelimit'
-  s.version   = '1.2.0'
+  s.version   = '1.2.1'
   s.author    = 'Jeremy Daer'
   s.email     = 'jeremydaer@gmail.com'
   s.homepage  = 'https://github.com/jeremy/rack-ratelimit'


### PR DESCRIPTION
This enables one to use the env values if needed to set the rate (for example, to set a different rate for different users)